### PR TITLE
Allow routes with multiple segments.

### DIFF
--- a/build.js
+++ b/build.js
@@ -2,10 +2,11 @@
 
 var _ = require('lodash');
 var fs = require('fs');
+var mkdirp = require('mkdirp');
 var path = require('path');
 var React = require('react');
 var Router = require('react-router');
-require('node-jsx').install();
+require('node-jsx').install({extension: '.jsx'});
 
 var routes = require('./routes.jsx');
 
@@ -35,15 +36,15 @@ module.exports = function(options) {
       });
     */
   // - Add custom <head> options to react-html
-  // - Map links to baseUrl? 
+  // - Map links to baseUrl?
 
   options.routes.map(function(route, i) {
     Router.run(routes(options), options.baseUrl + route.path, function(Handler, state) {
       var html = React.renderToString(React.createElement(Handler, options.props));
       //var dir = path.join(__dirname, options.dest + route.path + '/');
-      var dir = path.join(options.dest, route.path); 
+      var dir = path.join(options.dest, route.path);
       if (!fs.existsSync(dir)) {
-        fs.mkdirSync(dir);
+        mkdirp.sync(dir);
       }
       var filename = path.join(dir, 'index.html');
       fs.writeFileSync(filename, html);

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "lodash": "^3.5.0",
+    "mkdirp": "^0.5.1",
     "node-jsx": "^0.12.4"
   },
   "devDependencies": {


### PR DESCRIPTION
When using paths with multiple segments, the build method throws errors. I get the following pseudo error with a route `category/base`.

```
Error: ENOENT, no such file or directory '[path-to-app]/category/base'
```

This is because `fs.mkdirSync` won't recursively create parent directories. Using `mkdirp` fixed the error for me.
